### PR TITLE
feat: コロン（：）と箇条書きの機械的組み合わせパターンの検出機能を追加

### DIFF
--- a/.github/instructions/test.instructions.md
+++ b/.github/instructions/test.instructions.md
@@ -1,0 +1,50 @@
+---
+applyTo: '**/*.ts'
+---
+
+
+## テスト
+
+完全なテストは次のように行います。
+README.mdのチェックをtextlintで行い、ルールのテストは`textlint-tester`を使用します。
+
+```
+npm test
+```
+
+ルールのテストは`textlint-tester`を使用して、ルールのテストを実装する
+
+Unit Testの実行方法
+
+```bash
+npm run test:unit
+```
+
+特定のルールのみをUnit Testする場合は、以下のように実行します。
+
+```bash
+npm run test:unit -- --grep no-repetitive-expressions
+```
+
+実際に `textlint` コマンドを使ってルールを適用する場合は、以下のように実行します。
+
+```
+npm test
+```
+
+## ダミーファイルを使ったテスト
+
+- Git管理下にダミーファイルは作らない
+- `tmp/` ディレクトリを作成し、そこにダミーファイルを配置してテストを行う
+
+```
+#! /bin/bash
+set -ex
+
+mkdir -p tmp/
+npm install --save-dev . textlint technological-book-corpus-ja --prefix tmp/
+cd tmp
+# ダミーファイルを作成
+echo "ダミーファイル" > dummy.md
+./node_modules/.bin/textlint --preset @textlint-ja/ai-writing dummy.md
+```

--- a/test/rules/ai-tech-writing-guideline.test.ts
+++ b/test/rules/ai-tech-writing-guideline.test.ts
@@ -17,6 +17,15 @@ tester.run("ai-tech-writing-guideline", rule, {
         {
             text: "システムがデータを検証します。エラーが発生した場合、ログファイルに記録されます。",
             options: { enableDocumentAnalysis: false }
+        },
+        // 自然な箇条書きの導入例
+        {
+            text: "Vueのリアクティビティシステムは確かに便利ですが、その仕組みの見えにくさが気になります。\nたとえば、次のような点が見えにくいと感じます。\n\n- refとreactiveの使い分けが最初は分からない。",
+            options: { enableDocumentAnalysis: false }
+        },
+        {
+            text: "JSXはJavaScriptの中でUIを記述するため、プログラマーにとって理解しやすいです。\nたとえば、JSXの次のような点がわかりやすいと思っています。\n\n- 条件分岐やループは通常のJavaScriptの記法",
+            options: { enableDocumentAnalysis: false }
         }
     ],
     invalid: [
@@ -102,6 +111,27 @@ tester.run("ai-tech-writing-guideline", rule, {
                 {
                     message:
                         "【明確性】受動態表現が検出されました。「システムが○○を実行する」のような能動態への変更を検討してください。"
+                }
+            ]
+        },
+        // 構造化の問題（コロンと箇条書きの組み合わせ）
+        {
+            text: "Vueのリアクティビティシステムは確かに便利ですが、その仕組みの見えにくさが気になります。例えば：\n\n- refとreactiveの使い分けが最初は分からない。",
+            options: { enableDocumentAnalysis: false },
+            errors: [
+                {
+                    message:
+                        "【構造化】コロン（：）で終わる文の直後の箇条書きは機械的な印象を与える可能性があります。「たとえば、次のような点があります。」のような導入文を使った自然な表現を検討してください。"
+                }
+            ]
+        },
+        {
+            text: "JSXはJavaScriptの中でUIを記述するため、プログラマーにとって理解しやすいです：\n\n- 条件分岐やループは通常のJavaScriptの記法",
+            options: { enableDocumentAnalysis: false },
+            errors: [
+                {
+                    message:
+                        "【構造化】コロン（：）で終わる文の直後の箇条書きは機械的な印象を与える可能性があります。「たとえば、次のような点があります。」のような導入文を使った自然な表現を検討してください。"
                 }
             ]
         },


### PR DESCRIPTION
- ai-tech-writing-guideline ルールに新しい検出パターンを追加
- Document レベルでParagraph → List の連続パターンを解析
- 段落末尾がコロン（：、:）で終わり直後にリストが続く場合を検出
- 建設的で中立的なメッセージで自然な表現への改善を提案
- 既存の巨大な処理を関数に分割してモジュール化し保守性を向上
- テストケースを追加して機能の動作を保証

Closes #8