### PR TITLE
Feat/add option/no colon list formatting

### DIFF
--- a/src/rules/ai-tech-writing-guideline.ts
+++ b/src/rules/ai-tech-writing-guideline.ts
@@ -19,6 +19,8 @@ export interface Options {
     disableConsistencyGuidance?: boolean;
     disableClarityGuidance?: boolean;
     disableStructureGuidance?: boolean;
+    // Disable colon + list formatting checks (allows colon followed by bullet points)
+    "no-ai-colon-list-formatting"?: boolean;
     // Enable document-level analysis
     enableDocumentAnalysis?: boolean;
 }
@@ -31,6 +33,7 @@ const rule: TextlintRuleModule<Options> = (context, options = {}) => {
     const disableConsistencyGuidance = options.disableConsistencyGuidance ?? false;
     const disableClarityGuidance = options.disableClarityGuidance ?? false;
     const disableStructureGuidance = options.disableStructureGuidance ?? false;
+    const noAiColonListFormatting = options["no-ai-colon-list-formatting"] ?? false;
     const enableDocumentAnalysis = options.enableDocumentAnalysis ?? true;
 
     // テクニカルライティングガイダンスパターン
@@ -255,7 +258,9 @@ const rule: TextlintRuleModule<Options> = (context, options = {}) => {
         }
 
         // コロン + 箇条書きパターンの検出
-        detectMechanicalListIntroPattern(node);
+        if (!noAiColonListFormatting) {
+            detectMechanicalListIntroPattern(node);
+        }
         // 将来的にここに他の文書レベルの構造化パターンを追加できます
         // 例：
         // detectExcessiveNestedLists(node);

--- a/test/rules/ai-tech-writing-guideline.test.ts
+++ b/test/rules/ai-tech-writing-guideline.test.ts
@@ -39,6 +39,15 @@ tester.run("ai-tech-writing-guideline", rule, {
         {
             text: "パフォーマンス改善の手法を紹介します。以下にその手法を示します。\n\n- コード最適化\n- キャッシュ活用",
             options: { enableDocumentAnalysis: false }
+        },
+        // no-ai-colon-list-formatting オプション true の場合（コロン+箇条書きを許可）
+        {
+            text: "フレームワークの特徴は以下の通りです：\n\n- 高速な処理\n- 簡単な設定",
+            options: { "no-ai-colon-list-formatting": true, enableDocumentAnalysis: false }
+        },
+        {
+            text: "設定項目について説明します。例えば。\n\n- 基本設定\n- 詳細設定",
+            options: { "no-ai-colon-list-formatting": true, enableDocumentAnalysis: false }
         }
     ],
     invalid: [
@@ -198,6 +207,37 @@ tester.run("ai-tech-writing-guideline", rule, {
                 {
                     message:
                         "【簡潔性】冗長な助動詞表現が検出されました。「できます」または「します」への簡潔化を検討してください。"
+                }
+            ]
+        },
+        // no-ai-colon-list-formatting オプション false の場合（デフォルト動作：エラーを検出）
+        {
+            text: "フレームワークの特徴は以下の通りです：\n\n- 高速な処理\n- 簡単な設定",
+            options: { "no-ai-colon-list-formatting": false, enableDocumentAnalysis: false },
+            errors: [
+                {
+                    message:
+                        "【構造化】コロン（：）で終わる文の直後の箇条書きは機械的な印象を与える可能性があります。「たとえば、次のような点があります。」のような導入文を使った自然な表現を検討してください。"
+                }
+            ]
+        },
+        {
+            text: "APIの使用方法について：\n\n- GET リクエスト\n- POST リクエスト",
+            options: { "no-ai-colon-list-formatting": false, enableDocumentAnalysis: false },
+            errors: [
+                {
+                    message:
+                        "【構造化】コロン（：）で終わる文の直後の箇条書きは機械的な印象を与える可能性があります。「たとえば、次のような点があります。」のような導入文を使った自然な表現を検討してください。"
+                }
+            ]
+        },
+        {
+            text: "設定項目について説明します。例えば。\n\n- 基本設定\n- 詳細設定",
+            options: { "no-ai-colon-list-formatting": false, enableDocumentAnalysis: false },
+            errors: [
+                {
+                    message:
+                        "【構造化】接続表現と句点で終わる文の直後の箇条書きは機械的な印象を与える可能性があります。「たとえば、次のような点があります。」のような自然な導入文を検討してください。"
                 }
             ]
         }

--- a/test/rules/ai-tech-writing-guideline.test.ts
+++ b/test/rules/ai-tech-writing-guideline.test.ts
@@ -42,7 +42,7 @@ tester.run("ai-tech-writing-guideline", rule, {
         },
         // no-ai-colon-list-formatting オプション true の場合（コロン+箇条書きを許可）
         {
-            text: "フレームワークの特徴は以下の通りです：\n\n- 高速な処理\n- 簡単な設定",
+            text: "フレームワークの特徴は以下の通りです：\n\n- 便利な機能\n- 簡単な設定",
             options: { "no-ai-colon-list-formatting": true, enableDocumentAnalysis: false }
         },
         {
@@ -212,7 +212,7 @@ tester.run("ai-tech-writing-guideline", rule, {
         },
         // no-ai-colon-list-formatting オプション false の場合（デフォルト動作：エラーを検出）
         {
-            text: "フレームワークの特徴は以下の通りです：\n\n- 高速な処理\n- 簡単な設定",
+            text: "フレームワークの特徴は以下の通りです：\n\n- 便利な機能\n- 簡単な設定",
             options: { "no-ai-colon-list-formatting": false, enableDocumentAnalysis: false },
             errors: [
                 {


### PR DESCRIPTION
## ✨ Overview

This PR introduces a new option `no-ai-colon-list-formatting` to the `ai-tech-writing-guideline` rule. The motivation is to allow flexibility for users who prefer colon + list formats without receiving unnecessary warnings.

By enabling this option, the rule will skip checks that flag colon-terminated sentences followed by bullet lists as mechanical.

---

## 🔧 Changes

List the key changes included in this PR:

- [X] Added/updated files or modules (`ai-tech-writing-guideline.ts`)
- [ ] Removed deprecated logic or configs
- [ ] Refactored for clarity/performance
- [ ] Other

---

## 📂 Related Issues

_No related issues._

---

## ✅ Checklist

Please confirm the following before requesting review:

- [x] Lint checks pass
- [x] Tests pass
- [ ] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [X] Descriptions and examples are clear

---

## 💬 Additional Notes

✅ Lint and test passed in local PR ([#1](https://github.com/atsushifx/textlint-rule-preset-ai-writing/pull/1))

Test cases were added to validate the behavior when the option is enabled or disabled. By default, colon + list still produces warnings, preserving current rule behavior.
